### PR TITLE
Introduce a New Signal Handling Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-hostel-huptainer
-----------------
+# hostel-huptainer #
+
 This program's purpose is to handle SIGHUP'ing docker container
 processes that have a `org.eff.certbot.cert_cns` label value matching
 the supplied string.
@@ -8,8 +8,8 @@ The name is a munging together of host, label, SIGHUP and Docker
 container; with host coming from hostname, el being 2 letters from
 label, hup being from SIGHUP and tainer being from container.
 
-Installation
-============
+## Installation ##
+
 Installation of this program is quite easy, as it only has one external
 dependency, and this program includes this dependency in its setup.py
 file.
@@ -22,18 +22,18 @@ That said, there are 3 ways that you can install this program;
 
    `pip install .`
 
-*  You can also use Docker to install/run this program. You can do this
-   like so when grabbing from the Docker Hub:
+*  You can also use a pre-built Docker image from the Docker Hub by
+   pulling the image like so:
 
    `docker pull jitsusama/hostel-huptainer`
 
-*  Finally, you can build the image from a clone of the source
+*  Finally, you can build a Docker image from a clone of the source
    repository like so:
 
    `docker build -t jitsusama/hostel-huptainer .`
 
-Usage
-=====
+## Usage ##
+
 This program relies on the `CERTBOT_HOSTNAME` environment variable
 being present upon invocation, as it's meant to be called somewhere
 downstream of a certbot program engaging with a manual-auth-hook or
@@ -44,49 +44,69 @@ program. With this in mind, I envision this program primarily being
 called by lets-do-dns via the `LETS_DO_POSTCMD` environment variable
 being passed to it.
 
-Here's an example of how you can use this program from the CLI directly
-when you installed the program via PIP:
+### Locally Installed ###
+
+Here's an example of using this program directly:
 
 ```bash
-   CERTBOT_HOSTNAME=myhost.mydomain.com \
-   hostel-huptainer
+CERTBOT_HOSTNAME=myhost.mydomain.com \
+hostel-huptainer
 ```
 
-Here's an example of how you can use this program from the CLI via
-certbot/lets-do-dns when you installed the program via PIP:
+Here's an example of how you can use this program via
+certbot/lets-do-dns:
 
 ```bash
-   DO_APIKEY=super-secret-key \
-   DO_DOMAIN=mydomain.com \
-   LETS_DO_POSTCMD=hostel-huptainer \
-   certbot certonly --manual -d myhostname.mydomain.com \
-       --preferred-challenges dns \
-       --manual-auth-hook lets-do-dns \
-       --manual-cleanup-hook lets-do-dns
+DO_APIKEY=super-secret-key \
+DO_DOMAIN=mydomain.com \
+LETS_DO_POSTCMD=hostel-huptainer \
+certbot certonly --manual -d myhostname.mydomain.com \
+   --preferred-challenges dns \
+   --manual-auth-hook lets-do-dns \
+   --manual-cleanup-hook lets-do-dns
 ```
+
+When using via certbot/lets-do-dns, you can simply invoke certbot like
+so when performing a certificate renewal and it will call
+hostel-huptainer only when a renewal is required:
+
+```bash
+DO_APIKEY=super-secret-key \
+DO_DOMAIN=mydomain.com \
+LETS_DO_POSTCMD=hostel-huptainer \
+certbot renew
+```
+
+### Via Docker ###
 
 Here's an example of how you can use this program from Docker when
 you pulled the image from the Docker Hub:
 
 ```bash
-   docker run -v "$(pwd)/my-cert-dir:/etc/letsencrypt" \
-       -v "/var/run/docker.sock:/var/run/docker.sock" \
-       -e "DO_APIKEY=super-secret-key" \
-       -e "DO_DOMAIN=mydomain.com" \
-       -e "LETS_DO_POSTCMD=hostel-huptainer" \
-       jitsusama/hostel-huptainer \
-       certonly --manual -d myhostname.mydomain.com \
-           --preferred-challenges dns \
-           --manual-auth-hook lets-do-dns \
-           --manual-cleanup-hook lets-do-dns
+docker run -v "$(pwd)/my-cert-dir:/etc/letsencrypt" \
+   -v "/var/run/docker.sock:/var/run/docker.sock" \
+   -e "DO_APIKEY=super-secret-key" \
+   -e "DO_DOMAIN=mydomain.com" \
+   -e "LETS_DO_POSTCMD=hostel-huptainer" \
+   jitsusama/hostel-huptainer \
+   certonly --manual -d myhostname.mydomain.com \
+       --preferred-challenges dns \
+       --manual-auth-hook lets-do-dns \
+       --manual-cleanup-hook lets-do-dns
 ```
 
-Note:
+When using via certbot/lets-do-dns, you can simply invoke certbot like
+so when performing a certificate renewal and it will call
+hostel-huptainer only when a renewal is required:
 
-In both of these circumstances, certbot would be providing the
-`CERTBOT_HOSTNAME` environment variable based on the `-d`
-hostname supplied via its invocation. The `lets-do-dns` program
-is programmed such that it will only call the passed
-`hostel-huptainer` program during the manual-cleanup-hook stage.
+```bash
+docker run -v "$(pwd)/my-cert-dir:/etc/letsencrypt" \
+   -v "/var/run/docker.sock:/var/run/docker.sock" \
+   -e "DO_APIKEY=super-secret-key" \
+   -e "DO_DOMAIN=mydomain.com" \
+   -e "LETS_DO_POSTCMD=hostel-huptainer" \
+   jitsusama/hostel-huptainer \
+   certbot renew
+```
 
 [1]: https://github.com/jitsusama/lets-do-dns

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ CERTBOT_HOSTNAME=myhost.mydomain.com \
 hostel-huptainer
 ```
 
+By default hostel-huptainer will reload matching containers by sending
+them a SIGHUP signal. You can override this default by passing the
+`--signal` or `-s` option and specifying either `reload` (SIGHUP)
+or `restart` (SIGINT followed by process relaunch) like so:
+
+```bash
+CERTBOT_HOSTNAME=myhost.mydomain.com \
+hostel-huptainer --signal restart
+```
+
 Here's an example of how you can use this program via
 certbot/lets-do-dns:
 

--- a/README.rst
+++ b/README.rst
@@ -24,14 +24,14 @@ That said, there are 3 ways that you can install this program;
 
       pip install .
 
-*  You can also use Docker to install/run this program. You can do this
-   like so when grabbing from the Docker Hub:
+*  You can also use a pre-built Docker image from the Docker Hub by
+   pulling the image like so:
 
    .. code-block:: bash
 
       docker pull jitsusama/hostel-huptainer
 
-*  Finally, you can build the image from a clone of the source
+*  Finally, you can build a Docker image from a clone of the source
    repository like so:
 
    .. code-block:: bash
@@ -50,16 +50,17 @@ program. With this in mind, I envision this program primarily being
 called by lets-do-dns via the ``LETS_DO_POSTCMD`` environment variable
 being passed to it.
 
-Here's an example of how you can use this program from the CLI directly
-when you installed the program via PIP:
+Locally Installed
++++++++++++++++++
+Here's an example of using this program directly:
 
 .. code-block:: bash
 
    CERTBOT_HOSTNAME=myhost.mydomain.com \
    hostel-huptainer
 
-Here's an example of how you can use this program from the CLI via
-certbot/lets-do-dns when you installed the program via PIP:
+Here's an example of how you can use this program via
+certbot/lets-do-dns:
 
 .. code-block:: bash
 
@@ -71,6 +72,19 @@ certbot/lets-do-dns when you installed the program via PIP:
        --manual-auth-hook lets-do-dns \
        --manual-cleanup-hook lets-do-dns
 
+When using via certbot/lets-do-dns, you can simply invoke certbot like
+so when performing a certificate renewal and it will call
+hostel-huptainer only when a renewal is required:
+
+.. code-block:: bash
+
+   DO_APIKEY=super-secret-key \
+   DO_DOMAIN=mydomain.com \
+   LETS_DO_POSTCMD=hostel-huptainer \
+   certbot renew
+
+Via Docker
+++++++++++
 Here's an example of how you can use this program from Docker when
 you pulled the image from the Docker Hub:
 
@@ -87,12 +101,18 @@ you pulled the image from the Docker Hub:
            --manual-auth-hook lets-do-dns \
            --manual-cleanup-hook lets-do-dns
 
-.. note::
+When using via certbot/lets-do-dns, you can simply invoke certbot like
+so when performing a certificate renewal and it will call
+hostel-huptainer only when a renewal is required:
 
-   In both of these circumstances, certbot would be providing the
-   ``CERTBOT_HOSTNAME`` environment variable based on the ``-d``
-   hostname supplied via its invocation. The ``lets-do-dns`` program
-   is programmed such that it will only call the passed
-   ``hostel-huptainer`` program during the manual-cleanup-hook stage.
+.. code-block:: bash
+
+   docker run -v "$(pwd)/my-cert-dir:/etc/letsencrypt" \
+       -v "/var/run/docker.sock:/var/run/docker.sock" \
+       -e "DO_APIKEY=super-secret-key" \
+       -e "DO_DOMAIN=mydomain.com" \
+       -e "LETS_DO_POSTCMD=hostel-huptainer" \
+       jitsusama/hostel-huptainer \
+       certbot renew
 
 .. _lets-do-dns: https://github.com/jitsusama/lets-do-dns

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,16 @@ Here's an example of using this program directly:
    CERTBOT_HOSTNAME=myhost.mydomain.com \
    hostel-huptainer
 
+By default hostel-huptainer will reload matching containers by sending
+them a SIGHUP signal. You can override this default by passing the
+``--signal`` or ``-s`` option and specifying either ``reload`` (SIGHUP)
+or ``restart`` (SIGINT followed by process relaunch) like so:
+
+.. code-block:: bash
+
+    CERTBOT_HOSTNAME=myhost.mydomain.com \
+    hostel-huptainer --signal restart
+
 Here's an example of how you can use this program via
 certbot/lets-do-dns:
 

--- a/source/hostel_huptainer/__main__.py
+++ b/source/hostel_huptainer/__main__.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from hostel_huptainer.arguments import Arguments
-from hostel_huptainer.containers import MatchingContainers, sighup
+from hostel_huptainer.containers import MatchingContainers, send_signal
 from hostel_huptainer.environment import Environment
 from hostel_huptainer.errors import InputError, ContainerError
 from hostel_huptainer.system import abnormal_exit, error_message
@@ -13,7 +13,7 @@ from hostel_huptainer.system import abnormal_exit, error_message
 def main():
     """Main program logic."""
     try:
-        Arguments(sys.argv)
+        arguments = Arguments(sys.argv)
         environment = Environment(os.environ)
         containers = MatchingContainers(environment.hostname)
     except InputError as error:
@@ -22,7 +22,7 @@ def main():
         _handle_error(error)
     else:
         for container in containers:
-            sighup(container)
+            send_signal(arguments.signal_method, container)
 
 
 def _handle_error(error):

--- a/source/hostel_huptainer/arguments.py
+++ b/source/hostel_huptainer/arguments.py
@@ -18,8 +18,7 @@ environment variable in order to run. When this is called in connection
 with the certbot program, this variable should automatically be set.'''
 
         parser = ArgumentParser(description=description, epilog=epilog)
-        parser.add_argument(
-            '-v', '--version', action='version', version=__version__)
+
         parser.add_argument(
             '-s', '--signal', dest='signal_method', default='reload',
             choices=['reload', 'restart'],
@@ -27,4 +26,8 @@ with the certbot program, this variable should automatically be set.'''
                   'processes to be SIGHUP\'d, or choose restart if '
                   'you would like matching processes to be stopped '
                   'and then restarted.'))
+
+        parser.add_argument(
+            '-v', '--version', action='version', version=__version__)
+
         parser.parse_args(argument_vector[1:])

--- a/source/hostel_huptainer/arguments.py
+++ b/source/hostel_huptainer/arguments.py
@@ -8,6 +8,12 @@ class Arguments(object):
     """Parses command line arguments and acts upon them."""
 
     def __init__(self, argument_vector):
+        self._parser = None
+        self._initialize_parser()
+        self._attach_arguments_to_parser()
+        self._parse_passed_arguments(argument_vector)
+
+    def _initialize_parser(self):
         description = '''\
 SIGHUP docker container processes that have an org.eff.certbot.cert_cns
 label value matching the hostname specified in the CERTBOT_HOSTNAME
@@ -17,9 +23,10 @@ This program requires the CERTBOT_HOSTNAME variable to be present as an
 environment variable in order to run. When this is called in connection
 with the certbot program, this variable should automatically be set.'''
 
-        parser = ArgumentParser(description=description, epilog=epilog)
+        self._parser = ArgumentParser(description=description, epilog=epilog)
 
-        parser.add_argument(
+    def _attach_arguments_to_parser(self):
+        self._parser.add_argument(
             '-s', '--signal', dest='signal_method', default='reload',
             choices=['reload', 'restart'],
             help=('choose reload (the default) if you want matching '
@@ -27,7 +34,8 @@ with the certbot program, this variable should automatically be set.'''
                   'you would like matching processes to be stopped '
                   'and then restarted.'))
 
-        parser.add_argument(
+        self._parser.add_argument(
             '-v', '--version', action='version', version=__version__)
 
-        parser.parse_args(argument_vector[1:])
+    def _parse_passed_arguments(self, argument_vector):
+        self._parser.parse_args(argument_vector[1:])

--- a/source/hostel_huptainer/arguments.py
+++ b/source/hostel_huptainer/arguments.py
@@ -9,9 +9,15 @@ class Arguments(object):
 
     def __init__(self, argument_vector):
         self._parser = None
+        self._parsed_values = None
+
         self._initialize_parser()
         self._attach_arguments_to_parser()
         self._parse_passed_arguments(argument_vector)
+
+    def __getattr__(self, item):
+        """Grab unknown properties from parsed argument namespace."""
+        return self._parsed_values.__getattribute__(item)
 
     def _initialize_parser(self):
         description = '''\
@@ -23,7 +29,8 @@ This program requires the CERTBOT_HOSTNAME variable to be present as an
 environment variable in order to run. When this is called in connection
 with the certbot program, this variable should automatically be set.'''
 
-        self._parser = ArgumentParser(description=description, epilog=epilog)
+        self._parser = ArgumentParser(
+            description=description, epilog=epilog)
 
     def _attach_arguments_to_parser(self):
         self._parser.add_argument(
@@ -38,4 +45,5 @@ with the certbot program, this variable should automatically be set.'''
             '-v', '--version', action='version', version=__version__)
 
     def _parse_passed_arguments(self, argument_vector):
-        self._parser.parse_args(argument_vector[1:])
+        self._parsed_values = self._parser.parse_args(
+            argument_vector[1:])

--- a/source/hostel_huptainer/arguments.py
+++ b/source/hostel_huptainer/arguments.py
@@ -20,4 +20,11 @@ with the certbot program, this variable should automatically be set.'''
         parser = ArgumentParser(description=description, epilog=epilog)
         parser.add_argument(
             '-v', '--version', action='version', version=__version__)
+        parser.add_argument(
+            '-s', '--signal', dest='signal_method', default='reload',
+            choices=['reload', 'restart'],
+            help=('choose reload (the default) if you want matching '
+                  'processes to be SIGHUP\'d, or choose restart if '
+                  'you would like matching processes to be stopped '
+                  'and then restarted.'))
         parser.parse_args(argument_vector[1:])

--- a/source/hostel_huptainer/containers.py
+++ b/source/hostel_huptainer/containers.py
@@ -14,8 +14,12 @@ def csv_contains_value(csv_list, value):
 
 
 def send_signal(signal_method, container):
-    """Use the specified method to reload or restart the container."""
-    container.kill(signal='SIGHUP')
+    """Reload or restart the container."""
+    if signal_method == 'reload':
+        container.kill(signal='SIGHUP')
+
+    elif signal_method == 'restart':
+        container.restart()
 
 
 class MatchingContainers(object):

--- a/source/hostel_huptainer/containers.py
+++ b/source/hostel_huptainer/containers.py
@@ -13,8 +13,8 @@ def csv_contains_value(csv_list, value):
         item.strip() == value for item in item_list])
 
 
-def sighup(container):
-    """Send a SIGHUP kill signal to the passed container."""
+def send_signal(signal_method, container):
+    """Use the specified method to reload or restart the container."""
     container.kill(signal='SIGHUP')
 
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -3,10 +3,12 @@
 import docker
 import pytest
 
-PYTHON_HUPPABLE_CMD_ARGS = ['python2', '-c', '''
+PYTHON_SIGNALLED_CMD_ARGS = ['python2', '-c', '''
 import signal
 def h(*args): raise Exception('HUPPED')
+def i(*args): raise Exception('TERMED')
 signal.signal(signal.SIGHUP, h)
+signal.signal(signal.SIGTERM, i)
 while True: pass''']
 
 
@@ -15,7 +17,7 @@ def python_container():
     client = docker.client.DockerClient()
     image = client.images.get('python:2.7')
     container = client.containers.create(
-        image=image, command=PYTHON_HUPPABLE_CMD_ARGS,
+        image=image, command=PYTHON_SIGNALLED_CMD_ARGS,
         labels={'org.eff.certbot.cert_cns': 'testhost.testdomain.tld'})
 
     yield container

--- a/tests/system/test_process_invocations.py
+++ b/tests/system/test_process_invocations.py
@@ -60,11 +60,9 @@ def test_does_not_reload_containers_with_mismatched_label(
             'CERTBOT_HOSTNAME': 'idontmatch.testdomain.tld'}))
 
     try:
-        python_container.wait(timeout=4)
+        python_container.wait(timeout=6)
     except requests.ReadTimeout:
-        pass
-
-    assert 'HUPPED' not in python_container.logs().decode()
+        assert 'HUPPED' not in python_container.logs().decode()
 
 
 def test_reloads_container_with_matching_label_when_asked(
@@ -90,8 +88,6 @@ def test_restarts_container_with_matching_label_when_asked(
             'CERTBOT_HOSTNAME': 'testhost.testdomain.tld'}))
 
     try:
-        python_container.wait(timeout=4)
+        python_container.wait(timeout=6)
     except requests.ReadTimeout:
-        pass
-
-    assert 'TERMED' in python_container.logs().decode()
+        assert 'TERMED' in python_container.logs().decode()

--- a/tests/system/test_process_invocations.py
+++ b/tests/system/test_process_invocations.py
@@ -37,7 +37,7 @@ def test_prints_version_when_version_argument_passed():
     assert __version__ in stdout.decode()
 
 
-def test_restarts_container_with_matching_label(
+def test_reloads_container_with_matching_label(
         python_container):
     python_container.start()
 
@@ -50,7 +50,7 @@ def test_restarts_container_with_matching_label(
     assert 'HUPPED' in python_container.logs().decode()
 
 
-def test_does_not_restart_containers_with_mismatched_label(
+def test_does_not_reload_containers_with_mismatched_label(
         python_container):
     python_container.start()
 
@@ -65,3 +65,25 @@ def test_does_not_restart_containers_with_mismatched_label(
         pass
 
     assert 'HUPPED' not in python_container.logs().decode()
+
+
+def test_reloads_container_with_matching_label_when_asked(
+        python_container):
+    subprocess.check_call(
+        args=['hostel-huptainer', '--signal', 'restart'],
+        env=os.environ.update({
+            'CERTBOT_HOSTNAME': 'testhost.testdomain.tld'}))
+
+    python_container.wait(timeout=2)
+    assert 'TERMED' in python_container.logs().decode()
+
+
+def test_restarts_container_with_matching_label_when_asked(
+        python_container):
+    subprocess.check_call(
+        args=['hostel-huptainer', '--signal', 'reload'],
+        env=os.environ.update({
+            'CERTBOT_HOSTNAME': 'testhost.testdomain.tld'}))
+
+    python_container.wait(timeout=2)
+    assert 'HUPPED' in python_container.logs().decode()

--- a/tests/system/test_process_invocations.py
+++ b/tests/system/test_process_invocations.py
@@ -70,20 +70,20 @@ def test_does_not_reload_containers_with_mismatched_label(
 def test_reloads_container_with_matching_label_when_asked(
         python_container):
     subprocess.check_call(
-        args=['hostel-huptainer', '--signal', 'restart'],
-        env=os.environ.update({
-            'CERTBOT_HOSTNAME': 'testhost.testdomain.tld'}))
-
-    python_container.wait(timeout=2)
-    assert 'TERMED' in python_container.logs().decode()
-
-
-def test_restarts_container_with_matching_label_when_asked(
-        python_container):
-    subprocess.check_call(
         args=['hostel-huptainer', '--signal', 'reload'],
         env=os.environ.update({
             'CERTBOT_HOSTNAME': 'testhost.testdomain.tld'}))
 
     python_container.wait(timeout=2)
     assert 'HUPPED' in python_container.logs().decode()
+
+
+def test_restarts_container_with_matching_label_when_asked(
+        python_container):
+    subprocess.check_call(
+        args=['hostel-huptainer', '--signal', 'restart'],
+        env=os.environ.update({
+            'CERTBOT_HOSTNAME': 'testhost.testdomain.tld'}))
+
+    python_container.wait(timeout=2)
+    assert 'TERMED' in python_container.logs().decode()

--- a/tests/system/test_process_invocations.py
+++ b/tests/system/test_process_invocations.py
@@ -60,7 +60,7 @@ def test_does_not_reload_containers_with_mismatched_label(
             'CERTBOT_HOSTNAME': 'idontmatch.testdomain.tld'}))
 
     try:
-        python_container.wait(timeout=2)
+        python_container.wait(timeout=4)
     except requests.ReadTimeout:
         pass
 
@@ -69,6 +69,8 @@ def test_does_not_reload_containers_with_mismatched_label(
 
 def test_reloads_container_with_matching_label_when_asked(
         python_container):
+    python_container.start()
+
     subprocess.check_call(
         args=['hostel-huptainer', '--signal', 'reload'],
         env=os.environ.update({
@@ -80,10 +82,16 @@ def test_reloads_container_with_matching_label_when_asked(
 
 def test_restarts_container_with_matching_label_when_asked(
         python_container):
+    python_container.start()
+
     subprocess.check_call(
         args=['hostel-huptainer', '--signal', 'restart'],
         env=os.environ.update({
             'CERTBOT_HOSTNAME': 'testhost.testdomain.tld'}))
 
-    python_container.wait(timeout=2)
+    try:
+        python_container.wait(timeout=4)
+    except requests.ReadTimeout:
+        pass
+
     assert 'TERMED' in python_container.logs().decode()

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -34,7 +34,8 @@ def test_passes_version_details_to_add_argument_before_parsing(
         mocker, version):
     stub_version = mocker.patch(
         'hostel_huptainer.arguments.__version__', value=version)
-    mock_parser = mocker.patch('hostel_huptainer.arguments.ArgumentParser')
+    mock_parser = mocker.patch(
+        'hostel_huptainer.arguments.ArgumentParser')
 
     Arguments(['hostel-huptainer'])
 
@@ -42,3 +43,16 @@ def test_passes_version_details_to_add_argument_before_parsing(
         mocker.call().add_argument(
             '-v', '--version', action='version', version=stub_version),
         mocker.call().parse_args(mocker.ANY)])
+
+
+def test_properly_adds_signal_argument_to_argument_parser(
+        mocker):
+    mock_parser = mocker.patch(
+        'hostel_huptainer.arguments.ArgumentParser')
+
+    Arguments(['hostel-huptainer'])
+
+    mock_parser.assert_has_calls([
+        mocker.call().add_argument(
+            '-s', '--signal', dest='signal_method', default='reload',
+            choices=['reload', 'restart'], help=mocker.ANY)])

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -6,7 +6,8 @@ from hostel_huptainer.arguments import Arguments
 
 
 def test_passes_usage_information_to_argumentparser(mocker):
-    mock_parser = mocker.patch('hostel_huptainer.arguments.ArgumentParser')
+    mock_parser = mocker.patch(
+        'hostel_huptainer.arguments.ArgumentParser')
 
     Arguments(['hostel-huptainer'])
 
@@ -21,7 +22,8 @@ def test_passes_usage_information_to_argumentparser(mocker):
 ])
 def test_passes_arguments_and_not_progname_to_parse_args(
         mocker, stub_argv, expected_args):
-    mock_parser = mocker.patch('hostel_huptainer.arguments.ArgumentParser')
+    mock_parser = mocker.patch(
+        'hostel_huptainer.arguments.ArgumentParser')
 
     Arguments(stub_argv)
 
@@ -56,3 +58,15 @@ def test_properly_adds_signal_argument_to_argument_parser(
         mocker.call().add_argument(
             '-s', '--signal', dest='signal_method', default='reload',
             choices=['reload', 'restart'], help=mocker.ANY)])
+
+
+@pytest.mark.parametrize('signal_method', ['reload', 'restart'])
+def test___getattr___grabs_parsed_namespace_attributes(mocker, signal_method):
+    stub_parser = mocker.patch(
+        'hostel_huptainer.arguments.ArgumentParser')
+    stub_parser.return_value.parse_args.return_value.__getattribute__ \
+        = lambda _: signal_method
+
+    arguments = Arguments(['hostel-huptainer', '--signal', signal_method])
+
+    assert arguments.__getattr__('signal_method') == signal_method

--- a/tests/unit/test_containers.py
+++ b/tests/unit/test_containers.py
@@ -9,7 +9,7 @@ import pytest
 from hostel_huptainer.errors import ContainerError
 
 from hostel_huptainer.containers import (
-    MatchingContainers, csv_contains_value, sighup)
+    MatchingContainers, csv_contains_value, send_signal)
 
 
 class TestCsvContains(object):
@@ -32,11 +32,11 @@ class TestCsvContains(object):
         assert not result
 
 
-class TestSighup(object):
-    def test_properly_calls_kill(self, mocker):
+class TestSendSignal(object):
+    def test_properly_sends_sighup_when_requested(self, mocker):
         mock_container = mocker.MagicMock()
 
-        sighup(mock_container)
+        send_signal('reload', mock_container)
 
         mock_container.assert_has_calls([mocker.call.kill(signal="SIGHUP")])
 

--- a/tests/unit/test_containers.py
+++ b/tests/unit/test_containers.py
@@ -40,6 +40,13 @@ class TestSendSignal(object):
 
         mock_container.assert_has_calls([mocker.call.kill(signal="SIGHUP")])
 
+    def test_properly_restarts_when_requested(self, mocker):
+        mock_container = mocker.MagicMock()
+
+        send_signal('restart', mock_container)
+
+        mock_container.assert_has_calls([mocker.call.restart()])
+
 
 class TestMatchingContainersInit(object):
     @pytest.mark.parametrize('label', ['thing1.com', 'arm1.thing2.com'])


### PR DESCRIPTION
This feature will allow for specifying an alternative to just having a SIGHUP signal being sent to matching containers. One scenario that I'm using this program for is reloading SSL certificates on various UNIX daemons upon them being updated. I've found that OpenSMTPd does not reload its configuration upon receiving a SIGHUP signal, instead, it kills itself. So, to handle situations like these, I plan to add a feature whereby you can choose to either signal a reload (SIGHUP) or signal a restart (SIGTERM followed by a restart, IE: `docker restart <service>`).

My plan is to introduce a new command line argument `--signal`/`-s`, which will take a value of either `reload` or `restart`. When this argument is not passed, the program will default to its current behaviour of performing a "reload" (SIGHUP).